### PR TITLE
ID:4734 Correctly initialize js-translations

### DIFF
--- a/lib/Foswiki/Plugins/JQTableSorterPlugin.pm
+++ b/lib/Foswiki/Plugins/JQTableSorterPlugin.pm
@@ -33,9 +33,9 @@ SCRIPTS
     "<link rel='stylesheet' type='text/css' media='all' href='%PUBURLPATH%/%SYSTEMWEB%/JQTableSorterPlugin/styles/theme.css' />"
   );
 
-  Foswiki::Func::addToZone( 'script', 'JQTABLESORTERPLUGIN::I18N', <<SCRIPT, 'jsi18nCore' );
-<script type="text/javascript" src="%PUBURLPATH%/%SYSTEMWEB%/JQTableSorterPlugin/scripts/i18n/jsi18n.de.js"></script>
-SCRIPT
+  if($Foswiki::cfg{Plugins}{JSi18nPlugin}{Enabled}) {
+    Foswiki::Plugins::JSi18nPlugin::JSI18N($Foswiki::Plugins::SESSION, 'JQTableSorterPlugin/scripts/i18n');
+  }
 
   Foswiki::Plugins::JQueryPlugin::createPlugin('jqp::sweetalert2');
 


### PR DESCRIPTION
Before it only worked, if somebody else initialized the core.
Also it always loaded the German translation.